### PR TITLE
Add Docker support for workshop system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 8000
+
+# Run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ SQLite en `app.db` (se crea automáticamente). Para resetear, borra `app.db` (pe
 
 ## Seguridad
 Este demo no implementa autenticación. Para producción agrega auth (por ej. OAuth2/Keycloak) y permisos por rol.
+
+## Ejecutar con Docker
+
+```bash
+docker build -t taller .
+docker run -p 8000:8000 --env-file .env taller
+```
+
+Abre `http://<IP_DEL_SERVIDOR>:8000/` desde los teléfonos en la misma red para que los técnicos puedan actualizar órdenes.


### PR DESCRIPTION
## Summary
- Add Dockerfile to containerize the FastAPI workshop app
- Document Docker usage to allow running on reception server and phones

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689cf4e4f8b083208004e8dc349c865a