### PR TITLE
Add cached analytics with cache invalidation on order updates

### DIFF
--- a/app/analytics.py
+++ b/app/analytics.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import time
+from functools import lru_cache
+from typing import Dict
+
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from .database import engine
+from .models import WorkOrder
+
+CACHE_TTL_SECONDS = 300  # 5 minutes
+
+
+def _cache_key() -> int:
+    """Return a time-based cache key that changes every TTL interval."""
+    return int(time.time() // CACHE_TTL_SECONDS)
+
+
+@lru_cache(maxsize=1)
+def _status_counts_cached(_: int) -> Dict[str, int]:
+    """Internal cached function computing order status counts."""
+    with Session(engine) as session:
+        rows = session.exec(
+            select(WorkOrder.status, func.count(WorkOrder.id)).group_by(WorkOrder.status)
+        ).all()
+    return {status: count for status, count in rows}
+
+
+def get_order_status_counts() -> Dict[str, int]:
+    """Return cached order counts grouped by status."""
+    return _status_counts_cached(_cache_key())
+
+
+def invalidate_cache() -> None:
+    """Clear analytics cache."""
+    _status_counts_cached.cache_clear()

--- a/app/routers/workorders.py
+++ b/app/routers/workorders.py
@@ -10,6 +10,7 @@ from sqlmodel import Session, select
 from app.database import get_session
 from app.models import Client, Device, WorkOrder, WorkOrderEvent
 from app.services.whatsapp import WhatsAppService
+from app import analytics
 
 
 router = APIRouter(prefix="/ordenes", tags=["ordenes"])
@@ -87,6 +88,8 @@ async def create_order(
     session.add(event)
     session.commit()
 
+    analytics.invalidate_cache()
+
     # Enviar WhatsApp de recepción
     wa = WhatsAppService()
     receipt_text = (
@@ -157,6 +160,8 @@ async def add_event(
     session.add(order)
 
     session.commit()
+
+    analytics.invalidate_cache()
 
     if notify:
         device = session.get(Device, order.device_id)


### PR DESCRIPTION
## Summary
- add analytics helpers backed by 5‑minute in-memory cache
- clear analytics cache whenever orders are created or updated

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d055dbcdc8320930dc177dc58e956