### PR TITLE
Add analytics endpoint for work order metrics

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from fastapi.templating import Jinja2Templates
 from app.database import init_db
 from app.routers import clients as clients_router
 from app.routers import workorders as workorders_router
+from app.routers import analytics
 
 
 app = FastAPI(title="Taller Servicio Técnico")
@@ -30,6 +31,7 @@ async def index(request: Request) -> HTMLResponse:
 
 app.include_router(workorders_router.router)
 app.include_router(clients_router.router)
+app.include_router(analytics.router)
 
 
 if __name__ == "__main__":

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func
+from sqlmodel import Session, select
+
+from app.database import get_session
+from app.models import WorkOrder, WorkOrderEvent
+
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+@router.get("/")
+def analytics_summary(session: Session = Depends(get_session)) -> Dict[str, Any]:
+    """Return basic analytics information about work orders."""
+
+    total_orders = session.exec(select(func.count(WorkOrder.id))).one()
+
+    # Orders grouped by status and month (YYYY-MM)
+    stmt = (
+        select(
+            func.strftime("%Y-%m", WorkOrder.created_at).label("month"),
+            WorkOrder.status,
+            func.count(WorkOrder.id).label("count"),
+        )
+        .group_by("month", WorkOrder.status)
+        .order_by("month")
+    )
+    status_month_rows = session.exec(stmt).all()
+    orders_by_status: List[Dict[str, Any]] = [
+        {"month": month, "status": status, "count": count}
+        for month, status, count in status_month_rows
+    ]
+
+    # Average time from creation to first delivered event (in seconds)
+    delivered_rows = session.exec(
+        select(WorkOrder.created_at, WorkOrderEvent.created_at)
+        .join(WorkOrderEvent, WorkOrderEvent.work_order_id == WorkOrder.id)
+        .where(WorkOrderEvent.status == "entregado")
+    ).all()
+    avg_seconds: Optional[float] = None
+    if delivered_rows:
+        durations = [
+            (delivered_at - created_at).total_seconds()
+            for created_at, delivered_at in delivered_rows
+        ]
+        avg_seconds = sum(durations) / len(durations)
+
+    return {
+        "total_orders": total_orders,
+        "orders_by_status": orders_by_status,
+        "avg_time_to_delivered_seconds": avg_seconds,
+    }
+


### PR DESCRIPTION
## Summary
- expose `/analytics` router providing order statistics
- register analytics router in main app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d0555f3748320b147a54c4421c15d