### PR TITLE
Add minimal landing page for Granular Electronics

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uvicorn
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -25,7 +25,7 @@ async def on_startup() -> None:
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request) -> HTMLResponse:
-    return RedirectResponse(url="/ordenes/")
+    return templates.TemplateResponse("index.html", {"request": request})
 
 
 app.include_router(workorders_router.router)

--- a/app/static/landing.css
+++ b/app/static/landing.css
@@ -1,0 +1,36 @@
+body{
+  margin:0;
+  font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica,Arial,sans-serif;
+  display:flex;
+  min-height:100vh;
+  align-items:center;
+  justify-content:center;
+  background:#f7f7f8;
+  color:#111;
+}
+
+.hero{
+  text-align:center;
+}
+
+.hero h1{
+  font-size:2.5rem;
+  margin-bottom:0.5rem;
+}
+
+.hero p{
+  margin-bottom:1.5rem;
+}
+
+.button{
+  background:#2563eb;
+  color:#fff;
+  padding:0.75rem 1.25rem;
+  border-radius:0.5rem;
+  text-decoration:none;
+}
+
+.button:hover{
+  background:#1d4ed8;
+}
+

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Granular Electronics</title>
+  <link rel="stylesheet" href="/static/landing.css" />
+</head>
+<body>
+  <section class="hero">
+    <h1>Granular Electronics</h1>
+    <p>Soluciones electrónicas modernas y minimalistas.</p>
+    <a class="button" href="/ordenes/">Entrar</a>
+  </section>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Add modern minimal landing page for Granular Electronics
- Style landing page with simple hero layout
- Serve new template at root instead of redirecting

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a5dd67dd208320973ad7a9008e4069